### PR TITLE
Add floating search widget

### DIFF
--- a/styles/injected-styles.css
+++ b/styles/injected-styles.css
@@ -245,6 +245,11 @@
     margin: 4px 0;
     font-family: 'IRANSansMobile', 'Vazirmatn', sans-serif !important;
 }
+.favorite-icon {
+    margin-left: 6px;
+    cursor: pointer;
+    color: #ffc107;
+}
 .sp-vs-tp-cheaper-text {
     color: #28a745;
     font-weight: bold;


### PR DESCRIPTION
## Summary
- create persistent search widget with history and favorites
- show widget on Snappfood or Tapsifood pages
- enable searching paired products and jump to counterpart vendor page
- style star icon for favorites

## Testing
- `node --check content/universal-injector.js`

------
https://chatgpt.com/codex/tasks/task_e_688a30768c8483338d6a9e28650667a6