### PR TITLE
Add categories and favorites to search widget

### DIFF
--- a/styles/injected-styles.css
+++ b/styles/injected-styles.css
@@ -206,6 +206,17 @@
     transition: all 0.2s ease;
     direction: rtl;
 }
+#sp-vs-tp-category {
+    width: 100%;
+    padding: 8px 12px;
+    border: 2px solid #e1e5e9;
+    border-radius: 12px;
+    margin-bottom: 10px;
+    font-family: 'IRANSansMobile', 'Vazirmatn', sans-serif !important;
+    font-size: 14px;
+    direction: rtl;
+    box-sizing: border-box;
+}
 #sp-vs-tp-search-input:focus {
     outline: none;
     border-color: #667eea;
@@ -249,6 +260,14 @@
     margin-left: 6px;
     cursor: pointer;
     color: #ffc107;
+}
+.price-source.sf {
+    color: #17a2b8;
+    font-weight: bold;
+}
+.price-source.tf {
+    color: #ff8c00;
+    font-weight: bold;
 }
 .sp-vs-tp-cheaper-text {
     color: #28a745;


### PR DESCRIPTION
## Summary
- enhance search results to label platform prices
- allow filtering by category or favourites
- add category dropdown for search widget
- style dropdown and platform labels

## Testing
- `node --check content/universal-injector.js`

------
https://chatgpt.com/codex/tasks/task_e_688a36e2415883338ad534292f5fcf8c